### PR TITLE
Support new rubocop config loading method signature

### DIFF
--- a/lib/rubocop/blueapron/inject.rb
+++ b/lib/rubocop/blueapron/inject.rb
@@ -10,9 +10,9 @@ module RuboCop
       )
 
       def self.defaults!
-        hash = YAML.load_file(DEFAULT_FILE)
         puts "configuration from #{DEFAULT_FILE}" if ConfigLoader.debug?
-        config = ConfigLoader.merge_with_default(hash, DEFAULT_FILE)
+        loaded_config = ConfigLoader.load_file(DEFAULT_FILE)
+        config = ConfigLoader.merge_with_default(loaded_config, DEFAULT_FILE)
 
         ConfigLoader.instance_variable_set(:@default_configuration, config)
       end

--- a/lib/rubocop/blueapron/version.rb
+++ b/lib/rubocop/blueapron/version.rb
@@ -1,8 +1,8 @@
 module RuboCop
   module Blueapron
     MAJOR = '0'.freeze
-    MINOR = '1'.freeze
-    PATCH = '1'.freeze
+    MINOR = '2'.freeze
+    PATCH = '0'.freeze
 
     VERSION = [MAJOR, MINOR, PATCH].join('.')
   end

--- a/rubocop-blueapron.gemspec
+++ b/rubocop-blueapron.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['LICENSE', 'README.md']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.34'
+  spec.add_runtime_dependency 'rubocop', '~> 0.47'
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
Looks like the merging of configs no longer takes a hash in the lastest Rubocop version - I borrowed the updated call format from [here](https://github.com/bbatsov/rubocop/blob/88dee4d9b24a40ff74dc772ffba2adfdea43b1ae/lib/rubocop/config_store.rb#L23L24).

@prsimp - not sure how to test this or where it gets published to (not seeing it in gemfury?)
