### PR TITLE
Update to latest version of rubocop

### DIFF
--- a/rubocop-blueapron.gemspec
+++ b/rubocop-blueapron.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['LICENSE.txt', 'README.md']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.47'
+  spec.add_runtime_dependency 'rubocop', '~> 0.55'
 
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418
<img width="295" alt="screen shot 2018-05-01 at 10 52 01 am" src="https://user-images.githubusercontent.com/1474314/39477588-b204cb0a-4d2d-11e8-9895-d26630b9e6c0.png">
